### PR TITLE
fix(docs): Correct image paths and cross-reference links for MkDocs

### DIFF
--- a/docs/explanation/architecture-overview.md
+++ b/docs/explanation/architecture-overview.md
@@ -23,7 +23,7 @@ By storing component data in contiguous memory blocks, ECS ensures that the CPU'
 
 Monitoring tasks are divided into three distinct, concurrent pipelines. This separation is a core design decision that provides **fault isolation** and allows each pipeline to be optimized for its specific workload.
 
-![Pipeline Flow Diagram](../../docs/images/pipeline-flow.png)
+![Pipeline Flow Diagram](../images/pipeline-flow.png)
 
 | Pipeline | Primary Function | Triggered By | Key Characteristic |
 | :--- | :--- | :--- | :--- |

--- a/docs/explanation/queueing-theory.md
+++ b/docs/explanation/queueing-theory.md
@@ -49,5 +49,5 @@ This intelligent, mathematically-grounded approach is what allows CPRA to guaran
 
 ### **Next Steps**
 
-*   **[Performance Tuning & SLOs](how-to/performance-tuning.md)**: Learn how to configure and tune the SLO targets for your environment.
-*   **[Monitor Configuration Schema](reference/config-schema.md)**: See where to define the `interval` and `timeout` that feed into the $\lambda$ and $\mu$ calculations.
+*   **[Performance Tuning & SLOs](../how-to/performance-tuning.md)**: Learn how to configure and tune the SLO targets for your environment.
+*   **[Monitor Configuration Schema](../reference/config-schema.md)**: See where to define the `interval` and `timeout` that feed into the $\lambda$ and $\mu$ calculations.

--- a/docs/how-to/performance-tuning.md
+++ b/docs/how-to/performance-tuning.md
@@ -47,5 +47,5 @@ To validate your tuning efforts, use the built-in profiling tools:
 
 ### **Next Steps**
 
-*   **[Queueing Theory for Dynamic Scaling](explanation/queueing-theory.md)**: Understand the mathematical model behind the dynamic scaling.
-*   **[Monitor Configuration Schema](reference/config-schema.md)**: Review the configuration fields that affect job arrival and service rates.
+*   **[Queueing Theory for Dynamic Scaling](../explanation/queueing-theory.md)**: Understand the mathematical model behind the dynamic scaling.
+*   **[Monitor Configuration Schema](../reference/config-schema.md)**: Review the configuration fields that affect job arrival and service rates.

--- a/docs/tutorials/your-first-monitor.md
+++ b/docs/tutorials/your-first-monitor.md
@@ -74,5 +74,5 @@ $ docker run -it --rm \
 
 ### **Next Steps**
 
-*   **[Monitor Configuration Schema](reference/config-schema.md)**: Explore all available options for `pulse`, `intervention`, and `codes`.
-*   **[Architecture Overview](explanation/architecture-overview.md)**: Understand the ECS core that powers this high-performance flow.
+*   **[Monitor Configuration Schema](../reference/config-schema.md)**: Explore all available options for `pulse`, `intervention`, and `codes`.
+*   **[Architecture Overview](../explanation/architecture-overview.md)**: Understand the ECS core that powers this high-performance flow.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix relative image and cross-reference links in documentation for correct MkDocs navigation.
> 
> - **Docs**:
>   - **`docs/explanation/architecture-overview.md`**:
>     - Update pipeline diagram image path to `../images/pipeline-flow.png`.
>   - **Cross-reference fixes (relative links)**:
>     - `docs/explanation/queueing-theory.md`: point Next Steps links to `../how-to/performance-tuning.md` and `../reference/config-schema.md`.
>     - `docs/how-to/performance-tuning.md`: point Next Steps links to `../explanation/queueing-theory.md` and `../reference/config-schema.md`.
>     - `docs/tutorials/your-first-monitor.md`: point Next Steps links to `../reference/config-schema.md` and `../explanation/architecture-overview.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1b1b7b9738d20c7e5db8618ab8ebbf0cf939fa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->